### PR TITLE
dont remove umlauts from query

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -10,3 +10,9 @@ function search(string $query = null, $options = [], $collection = null)
         $collection
     );
 }
+
+function sanitize_field($field) {
+  // prevent text collapse when removing <br>
+  $field = preg_replace('/<br>/', ' ', $field);
+  return preg_replace('/\s+|-/m', ' ', Str::unhtml($field));
+}

--- a/src/models/Providers/Sqlite.php
+++ b/src/models/Providers/Sqlite.php
@@ -95,8 +95,10 @@ class Sqlite extends Provider
 
         // Drop and create fresh virtual table
         $this->store->execute('DROP TABLE IF EXISTS models');
+        /* echo 'CREATE VIRTUAL TABLE models USING FTS5(' . $this->store->escape(implode(',', $columns)) . ', tokenize="unicode61 remove_diacritics 2 tokenchars \'' . static::$tokenize . '\'");'; */
+        /* die; */
         $this->store->execute(
-            'CREATE VIRTUAL TABLE models USING FTS5(' . $this->store->escape(implode(',', $columns)) . ', tokenize="unicode61 remove_diacritics 2 tokenchars \'' . static::$tokenize . '\'");'
+            'CREATE VIRTUAL TABLE models USING FTS5(' . $this->store->escape(implode(',', $columns)) . ', tokenize="unicode61 remove_diacritics 1 tokenchars \'' . static::$tokenize . '\'");'
         );
         // Insert each object into the table
         foreach ($data as $entry) {

--- a/src/models/Providers/Sqlite.php
+++ b/src/models/Providers/Sqlite.php
@@ -116,7 +116,7 @@ class Sqlite extends Provider
     public function search(string $query, array $options, $collection = null): array
     {
         // Remove punctuation from query
-        $query = preg_replace('/[^a-z0-9äöüÄÖÜß]+/i', '', $query);
+        $query = preg_replace('/[^a-z0-9äöüÄÖÜß]+/i', ' ', $query);
 
         // Generate options with defaults
         $options = array_merge($this->options, $options);

--- a/src/models/Providers/Sqlite.php
+++ b/src/models/Providers/Sqlite.php
@@ -116,7 +116,7 @@ class Sqlite extends Provider
     public function search(string $query, array $options, $collection = null): array
     {
         // Remove punctuation from query
-        $query = preg_replace('/[^a-z0-9]+/i', '', $query);
+        $query = preg_replace('/[^a-z0-9äöüÄÖÜß]+/i', '', $query);
 
         // Generate options with defaults
         $options = array_merge($this->options, $options);


### PR DESCRIPTION
changed  the regex to exclude german umlauts as well.
so that the query 'hühnchen' doesn't get transformed to 'hnchen'
there is maybe a better way?